### PR TITLE
seed.rb修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -192,7 +192,7 @@ z_category_questions.each do |q|
     category: z_category
 
   )
-  
+
   question.choices.destroy_all
 
   q[:choices].each do |choice_text|
@@ -598,7 +598,7 @@ twochannel_category_questions.each do |q|
   )
 
   question.choices.destroy_all
-  
+
   q[:choices].each do |choice_text|
     question.choices.create!(
       content: choice_text,


### PR DESCRIPTION
写メの解答が登録されていなかった為、修正。

またdb:seedをするたびにcreate!で問題が重複していたため、重複したものをDBから削除し、find_or_create_by!で重複しないように修正。